### PR TITLE
Fix bug on ordering call histories

### DIFF
--- a/QuickStart/CallHistory/CallHistory.swift
+++ b/QuickStart/CallHistory/CallHistory.swift
@@ -21,7 +21,7 @@ struct CallHistory: Codable {
     
     static var dateFormatter: DateFormatter {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "YYYY/MM/d HH:mm"
+        dateFormatter.dateFormat = "YYYY/MM/dd HH:mm"
         return dateFormatter
     }
     


### PR DESCRIPTION
There was bug on ordering call histories: Call logs on Jun 9th was on the top of the list