### PR TITLE
Fix error on configure app ID

### DIFF
--- a/QuickStart/AppDelegate.swift
+++ b/QuickStart/AppDelegate.swift
@@ -25,6 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // MARK: SendBirdCall.configure(appId:)
         // See [here](https://github.com/sendbird/quickstart-calls-ios#creating-a-sendbird-application) for the application ID.
+        // If you want to sign in with QR code, don't configure your app ID in code.
         // SendBirdCall.configure(appId: YOUR_APP_ID)
 
         self.autoSignIn { error in
@@ -80,8 +81,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func authenticate(with credential: Credential, completionHandler: @escaping (Error?) -> Void) {
-        // Configure app ID before authenticate
-        SendBirdCall.configure(appId: credential.appId)
+        // Configure app ID before authenticate when there is no configured app ID
+        if SendBirdCall.appId == nil { SendBirdCall.configure(appId: credential.appId) }
         
         // Authenticate
         let authParams = AuthenticateParams(userId: credential.userId, accessToken: credential.accessToken)

--- a/QuickStart/Extensions/UserDefaults+QuickStart.swift
+++ b/QuickStart/Extensions/UserDefaults+QuickStart.swift
@@ -39,8 +39,10 @@ extension UserDefaults {
 
 extension UserDefaults {
     func clear() {
-        let keys = Key.allCases.filter { $0 != .voipPushToken }
-        keys.map { $0.value }.forEach(UserDefaults.standard.removeObject)
+        Key.allCases
+            .filter { $0 != .voipPushToken }
+            .map { $0.value }
+            .forEach(UserDefaults.standard.removeObject)
     }
 }
 


### PR DESCRIPTION
### Error
When use `configure(appId:)` method in AppDelegate didFinishLaunching, the configured app ID is reset by stored app ID. 

### Fixed
The stored app ID is only valid when `SendBirdCall.appId` has empty value.
