### PR TITLE
Fix bug on end result message in Recents view

### DIFF
--- a/QuickStart/CallHistory/CallHistory.swift
+++ b/QuickStart/CallHistory/CallHistory.swift
@@ -39,7 +39,7 @@ struct CallHistory: Codable {
         
         self.startedAt = CallHistory.dateFormatter.string(from: Date(timeIntervalSince1970: Double(callLog.startedAt) / 1000))
         self.duration = callLog.duration.durationText()
-        self.endResult = callLog.endResult.rawValue
+        self.endResult = CallStatus.ended(result: callLog.endResult.rawValue).message
     }
 }
 

--- a/QuickStart/Dial/CallStatus.swift
+++ b/QuickStart/Dial/CallStatus.swift
@@ -13,9 +13,14 @@ enum CallStatus {
     
     var message: String {
         switch self {
-            case .connecting: return "call connecting..."
-            case .muted(let user): return "\(user) is muted"
-            case .ended(let result): return result.replacingOccurrences(of: "_", with: " ")
+            case .connecting:
+                return "call connecting..."
+            case .muted(let user):
+                return "\(user) is muted"
+            case .ended(let result):
+                return result
+                    .replacingOccurrences(of: "_", with: " ")
+                    .capitalizingFirstLetter()
         }
     }
 }

--- a/QuickStart/Extensions/String+QuickStart.swift
+++ b/QuickStart/Extensions/String+QuickStart.swift
@@ -23,6 +23,10 @@ extension String {
             return self.trimmed
         }
     }
+    
+    public func capitalizingFirstLetter() -> String {
+        return prefix(1).capitalized + dropFirst()
+    }
 }
 
 extension Optional where Wrapped == String {


### PR DESCRIPTION
Issue: In Recents view, end result: "connection_lost"; Call view, end result: "connection lost"
Fixed: Recents shows capitalized end result without snake case like "**C**onnection lost"